### PR TITLE
Fix Django 1.9 warning

### DIFF
--- a/sortedm2m_filter_horizontal_widget/forms.py
+++ b/sortedm2m_filter_horizontal_widget/forms.py
@@ -7,7 +7,12 @@ from django.db.models.query import QuerySet
 from django.utils.encoding import force_text
 from django.utils.html import conditional_escape, escape
 from django.utils.safestring import mark_safe
-from django.forms.util import flatatt
+
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
+
 from django.utils.translation import ugettext_lazy as _
 
 


### PR DESCRIPTION
Hello, this patch fix Django 1.9 warning:

`
lib/python3.5/site-packages/sortedm2m_filter_horizontal_widget/forms.py:10: RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.
  from django.forms.util import flatatt
`